### PR TITLE
Repo_name file

### DIFF
--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,0 +1,1 @@
+arax-os-overlay


### PR DESCRIPTION
adding the file to fix emerge "warning" message "WARNING: One or more repositories have missing repo_name entries:

	/var/lib/layman/arax-overlay/profiles/repo_name

NOTE: Each repo_name entry should be a plain text file containing a
unique name for the repository on the first line."